### PR TITLE
Updating URL for GlusterFS Repo GPG key.

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -9,7 +9,7 @@
 
 - name: Import GlusterFS GPG key.
   rpm_key:
-    key: "http://download.gluster.org/pub/gluster/glusterfs/LATEST/CentOS/pub.key"
+    key: "https://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/pub.key"
     state: present
 
 - name: Ensure GlusterFS is installed.


### PR DESCRIPTION
The URL for the GluserFS Repo GPG key doesn't work anymore. This update it to what it should be now.