### PR TITLE
Allow the client or server modules to be installed independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ You can specify a `default_release` for apt on Debian/Ubuntu by overriding this 
 
 For Ubuntu, specify whether to use the official Gluster PPA, and which version of the PPA to use. See Gluster's [Getting Started Guide](http://www.gluster.org/community/documentation/index.php/Getting_started_install) for more info.
 
+    glusterfs_gluster_components:
+      - glusterfs-server
+      - glusterfs-client
+
+You can select whether to install the server component, client component or both (default)
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,6 @@
 glusterfs_default_release: ""
 glusterfs_ppa_use: yes
 glusterfs_ppa_version: "3.5"
+glusterfs_gluster_components:
+  - glusterfs-server
+  - glusterfs-client

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,4 @@
 
 - name: Ensure GlusterFS is started and enabled at boot.
   service: "name={{ glusterfs_daemon }} state=started enabled=yes"
+  when: "glusterfs_daemon in glusterfs_gluster_components"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,9 +11,7 @@
   apt:
     name: "{{ item }}"
     state: absent
-  with_items:
-    - glusterfs-server
-    - glusterfs-client
+  with_items: "{{ glusterfs_gluster_components }}"
   when: glusterfs_ppa_added.changed
 
 - name: Ensure GlusterFS is installed.
@@ -21,6 +19,4 @@
     name: "{{ item }}"
     state: installed
     default_release: "{{ glusterfs_default_release }}"
-  with_items:
-    - glusterfs-server
-    - glusterfs-client
+  with_items: "{{ glusterfs_gluster_components }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,4 +6,4 @@
 
 - name: Install Packages
   yum: name={{ item }}  state=present
-  with_items: {{ glusterfs_gluster_components }}
+  with_items: "{{ glusterfs_gluster_components }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,6 +6,4 @@
 
 - name: Install Packages
   yum: name={{ item }}  state=present
-  with_items:
-    - glusterfs-server
-    - glusterfs-client
+  with_items: {{ glusterfs_gluster_components }}


### PR DESCRIPTION
This is a non-breaking change that allows the role to be used to install glusterfs-client and glusterfs-server independently by creating a list `glusterfs_gluster_components` (defaulted to `[glusterfs-server, glusterfs-client]` )
To install client and server
```
- hosts: fs_servers
  vars_files:
    - vars.yml
  roles:
    - { role: glusterfs, glusterfs_gluster_components: [ glusterfs-server, glusterfs-client ] }
```
or
```
- hosts: fs_servers
  vars_files:
    - vars.yml
  roles:
    - { role: glusterfs }
```
to install client only 
```
- hosts: fs_clients
  vars_files:
    - vars.yml
  roles:
    - { role: glusterfs, glusterfs_gluster_components: [ glusterfs-client ] }
```