### PR TITLE
Updates include: to include_tasks:

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,10 @@
     - ansible_distribution_version == "14.04"
 
 # Setup/install tasks.
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-{{ ansible_distribution }}.yml
+- include_tasks: setup-{{ ansible_distribution }}.yml
   when: ansible_os_family == 'Debian'
 
 - name: Ensure GlusterFS is started and enabled at boot.


### PR DESCRIPTION
Fix for:
```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks/import_playbook instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting  deprecation_warnings=False in ansible.cfg.
```